### PR TITLE
Update PrintOne.php

### DIFF
--- a/src/PrintOne.php
+++ b/src/PrintOne.php
@@ -74,7 +74,7 @@ class PrintOne implements PrintOneApi
      */
     public function preview(Template $template, int $retryTimes = 5): string
     {
-        $response = $this->http->get("templates/preview/{$template->id}/{$template->version}");
+        $response = $this->http->post("templates/preview/{$template->id}/{$template->version}");
         if ($response->failed()) {
             throw new CouldNotFetchPreview('Something went wrong while fetching the preview from the Print.one API.');
         }


### PR DESCRIPTION
Het verkrijgen van de preview is een post request geworden. Zie [printone](https://portal.print.one/docs#tag/Templates/operation/previewTemplate)

Het meegeven van de mergeVariables is niet verplicht, want bij gebruik van de functie krijg ik nu goede previews terug.